### PR TITLE
Release version 1.7.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: pinta
 base: core20
-version: '1.7'
+version: '1.7.1'
 summary: 'Pinta: Painting Made Simple'
 description: |
   Pinta is a free, open source program for drawing and image editing.


### PR DESCRIPTION
This is a minor release on the gtk2 branch, so as far as I can tell there aren't any other changes needed? The 1.7.1 package has already been published to the pinta stable-builds PPA for all the recent Ubuntu versions including `focal`