### PR TITLE
Add common-id

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -94,6 +94,7 @@ environment:
 apps:
   pinta:
     command: bin/desktop-launch mono $SNAP/usr/lib/pinta/Pinta.exe
+    common-id: com.github.PintaProject.Pinta
     plugs: 
       - home
       - removable-media


### PR DESCRIPTION
See https://forum.snapcraft.io/t/support-for-appstream-id/2327
Currently GNOME Software will show two separate entries for the Flatpak and Snap. This will make it show a single app where the user can choose between Snap or Flatpak.
![gnome software](https://user-images.githubusercontent.com/54072917/143722602-46b9fe55-7dd6-4ab5-a4b2-35d6cfaa9e90.png)


Use same id as Flatpak: https://www.flathub.org/apps/details/com.github.PintaProject.Pinta