### PR TITLE
Update for Pinta 2.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,7 +9,6 @@ grade: stable
 confinement: strict
 license: MIT
 compression: lzo
-adopt-info: pinta
 
 package-repositories:
   - type: apt
@@ -22,7 +21,7 @@ parts:
   pinta:
     plugin: nil
     source: https://github.com/pintaproject/pinta.git
-    source-tag: 2.0
+    source-commit: 8f168ea3fd87264ecbbc3ad6eb75d6a4df136960 # 2.0 tag
     build-packages:
       - build-essential
       - pkg-config

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,6 @@
 name: pinta
 base: core20
+version: '2.0'
 summary: 'Pinta: Painting Made Simple'
 description: |
   Pinta is a freely licensed and cross platform simple drawing application.
@@ -21,6 +22,7 @@ parts:
   pinta:
     plugin: nil
     source: https://github.com/pintaproject/pinta.git
+    source-tag: 2.0
     build-packages:
       - build-essential
       - pkg-config
@@ -36,9 +38,6 @@ parts:
     stage-packages:
       - libglu1-mesa
       - dotnet-runtime-6.0
-    override-pull: |
-      snapcraftctl pull
-      snapcraftctl set-version "$(git rev-parse --short HEAD)"
     override-build: |
       export PATH=/usr/bin:${PATH}
       ./autogen.sh --prefix=${SNAPCRAFT_PART_INSTALL}/


### PR DESCRIPTION
This just sets the version number and git tag for the 2.0 release (the gtk3 branch can also be merged into `master` after this)
It looks like this was already updated for the bump to .NET 6, so there probably aren't any other changes required?