### PR TITLE
Update for Pinta 2.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: pinta
 base: core20
-version: '2.0.2'
+version: '2.1'
 summary: 'Pinta: Painting Made Simple'
 description: |
   Pinta is a freely licensed and cross platform simple drawing application.
@@ -21,7 +21,7 @@ parts:
   pinta:
     plugin: nil
     source: https://github.com/pintaproject/pinta.git
-    source-commit: 7ca0ee17d2a4b8e4f087f11508f1f448b445a690 # 2.0.2 tag
+    source-commit: 65667d140d8d150eca153e09684380850a8326c6 # 2.1 tag
     build-packages:
       - build-essential
       - pkg-config
@@ -33,10 +33,10 @@ parts:
       - libtool
       - gettext
       - intltool
-      - dotnet-sdk-6.0
+      - dotnet-sdk-7.0
     stage-packages:
       - libglu1-mesa
-      - dotnet-runtime-6.0
+      - dotnet-runtime-7.0
     override-build: |
       export PATH=/usr/bin:${PATH}
       ./autogen.sh --prefix=${SNAPCRAFT_PART_INSTALL}/


### PR DESCRIPTION
I'm planning to release 2.1 shortly, so for now the commit hash is the latest commit from the `release-2.1` branch

The main change is updating to .NET 7, although .NET 6 is still supported by Pinta if there are any issues with this

Other notes / questions:
- Does anything need to be enabled for the XDG screenshot portal support?
- Optionally, `webp-pixbuf-loader` could be included for WebP support (this is now a suggested dependency for Pinta), but this isn't required. It's not in the 20.04 repo so may be a bit more work to add